### PR TITLE
Fix linking and small tweaks to text.

### DIFF
--- a/about.html
+++ b/about.html
@@ -20,14 +20,14 @@
             <a href="index.html" style="filter:none"><img alt="Logo" src="./res/arbor-lines-proto-colour-full.svg" height="70"></a>
             <ul>
                 <li><a href="about.html">About</a></li>
-                <li><a href="cooperations.html">Cooperations</a></li>
-                <li><a href="https://github.com/arbor-sim/arbor/releases" target="_blank">News &nearr;</a></li>
-                <li><a href="https://www.github.com/arbor-sim/arbor/" target="_blank"><!--<span class="fa fa-github fa-lg"></span> -->GitHub &nearr;</a></li>
+                <li><a href="collaboration.html">Collaboration</a></li>
+                <li><a href="https://github.com/arbor-sim/arbor/releases">News &nearr;</a></li>
+                <li><a href="https://www.github.com/arbor-sim/arbor/"><!--<span class="fa fa-github fa-lg"></span> -->GitHub &nearr;</a></li>
             </ul>
         </nav>
         <p>Arbor: a multi-compartment neural network simulation library</p>
         <br>
-        <p><a href="https://arbor.readthedocs.io/en/latest/install" target="_blank"><b><span class="fa fa-download fa-lg"></span> Install</b></a><a href="https://arbor.readthedocs.io" target="_blank"><b><span class="fa fa-book fa-lg"></span> Documentation</b></a><a href="index.html#get-help"><b><span class="fa fa-question-circle fa-lg"></span> Get Help</b></a></p>
+        <p><a href="https://arbor.readthedocs.io/en/latest/install"><b><span class="fa fa-download fa-lg"></span> Install</b></a><a href="https://arbor.readthedocs.io"><b><span class="fa fa-book fa-lg"></span> Documentation</b></a><a href="index.html#get-help"><b><span class="fa fa-question-circle fa-lg"></span> Get Help</b></a></p>
     </header>
     <main>
         <article id="about">

--- a/collaboration.html
+++ b/collaboration.html
@@ -33,7 +33,7 @@
         <article id="Collaborations">
             <h2>Collaborations</h2>
 
-            <p>Use cases have included the neocortical simulations, macaque visual cortical areas, and olfactory bulb simulations. Arbor developers are collaborating with researchers and modelers in the development of efficient support for structural plasticity.</p>
+            <p>Use cases have included the neocortical simulations, macaque visual cortical areas, and olfactory bulb simulations. Arbor developers are collaborating with researchers and modellers in the development of efficient support for structural plasticity.</p>
 
             <p><strong>FIPPA: The Functional Interplay between Plasticity Processes on Arbor</strong><br>
             The goal of FIPPA is to extend the neural network simulator Arbor by key plasticity processes that will allow to simulate and analyze the long-term adaptive dynamics of large-scale, morphologically-detailed neuronal networks.The models that will be ported and augmented are based on the neuro-theoretical framework by <a href="https://www.tetzlab.com">tetzlab.com</a>. These models already indicated that the interplay between the plasticity processes of synaptic plasticity, synaptic scaling, and structural plasticity yields the formation and organization of motor memories.The research question is how multi-compartment neuron models with detailed synaptic dynamics can be utilized to improve the performance of such networks. Our main hypothesis is that the adaptive dynamics on the network level enforces the specialization of branches by the formation of synaptic clusters leading to the formation of self-sustaining long-term memories and an overall increase in storage capacity.</p>

--- a/collaboration.html
+++ b/collaboration.html
@@ -20,20 +20,20 @@
             <a href="index.html" style="filter:none"><img alt="Logo" src="./res/arbor-lines-proto-colour-full.svg" height="70"></a>
             <ul>
                 <li><a href="about.html">About</a></li>
-                <li><a href="cooperations.html">Cooperations</a></li>
-                <li><a href="https://github.com/arbor-sim/arbor/releases" target="_blank">News &nearr;</a></li>
-                <li><a href="https://www.github.com/arbor-sim/arbor/" target="_blank"><!--<span class="fa fa-github fa-lg"></span> -->GitHub &nearr;</a></li>
+                <li><a href="collaboration.html">Collaboration</a></li>
+                <li><a href="https://github.com/arbor-sim/arbor/releases">News &nearr;</a></li>
+                <li><a href="https://www.github.com/arbor-sim/arbor/"><!--<span class="fa fa-github fa-lg"></span> -->GitHub &nearr;</a></li>
             </ul>
         </nav>
         <p>Arbor: a multi-compartment neural network simulation library</p>
         <br>
-        <p><a href="https://arbor.readthedocs.io/en/latest/install" target="_blank"><b><span class="fa fa-download fa-lg"></span> Install</b></a><a href="https://arbor.readthedocs.io" target="_blank"><b><span class="fa fa-book fa-lg"></span> Documentation</b></a><a href="index.html#get-help"><b><span class="fa fa-question-circle fa-lg"></span> Get Help</b></a></p>
+        <p><a href="https://arbor.readthedocs.io/en/latest/install"><b><span class="fa fa-download fa-lg"></span> Install</b></a><a href="https://arbor.readthedocs.io"><b><span class="fa fa-book fa-lg"></span> Documentation</b></a><a href="index.html#get-help"><b><span class="fa fa-question-circle fa-lg"></span> Get Help</b></a></p>
     </header>
     <main>
         <article id="Collaborations">
             <h2>Collaborations</h2>
 
-            <p>Use cases have included the neocortical simulations, macaque visual cortical areas, and olfactory bulb simulations. Arbor developers are collaborating with researchers and modellers in the development of efficient support for structural plasticity.</p>
+            <p>Use cases have included the neocortical simulations, macaque visual cortical areas, and olfactory bulb simulations. Arbor developers are collaborating with researchers and modelers in the development of efficient support for structural plasticity.</p>
 
             <p><strong>FIPPA: The Functional Interplay between Plasticity Processes on Arbor</strong><br>
             The goal of FIPPA is to extend the neural network simulator Arbor by key plasticity processes that will allow to simulate and analyze the long-term adaptive dynamics of large-scale, morphologically-detailed neuronal networks.The models that will be ported and augmented are based on the neuro-theoretical framework by <a href="https://www.tetzlab.com">tetzlab.com</a>. These models already indicated that the interplay between the plasticity processes of synaptic plasticity, synaptic scaling, and structural plasticity yields the formation and organization of motor memories.The research question is how multi-compartment neuron models with detailed synaptic dynamics can be utilized to improve the performance of such networks. Our main hypothesis is that the adaptive dynamics on the network level enforces the specialization of branches by the formation of synaptic clusters leading to the formation of self-sustaining long-term memories and an overall increase in storage capacity.</p>

--- a/index.html
+++ b/index.html
@@ -20,20 +20,19 @@
             <a href="index.html" style="filter:none"><img alt="Logo" src="./res/arbor-lines-proto-colour-full.svg" height="70"></a>
             <ul>
                 <li><a href="about.html">About</a></li>
-                <li><a href="cooperations.html">Cooperations</a></li>
-                <li><a href="https://github.com/arbor-sim/arbor/releases" target="_blank">News &nearr;</a></li>
-                <li><a href="https://www.github.com/arbor-sim/arbor/" target="_blank"><!--<span class="fa fa-github fa-lg"></span> -->GitHub &nearr;</a></li>
+                <li><a href="collaboration.html">Collaboration</a></li>
+                <li><a href="https://github.com/arbor-sim/arbor/releases">News &nearr;</a></li>
+                <li><a href="https://www.github.com/arbor-sim/arbor/"><!--<span class="fa fa-github fa-lg"></span> -->GitHub &nearr;</a></li>
             </ul>
         </nav>
         <p>Arbor: a multi-compartment neural network simulation library</p>
         <br>
-        <p><a href="https://arbor.readthedocs.io/en/latest/install" target="_blank"><b><span class="fa fa-download fa-lg"></span> Install</b></a><a href="https://arbor.readthedocs.io" target="_blank"><b><span class="fa fa-book fa-lg"></span> Documentation</b></a><a href="index.html#get-help"><b><span class="fa fa-question-circle fa-lg"></span> Get Help</b></a></p>
+        <p><a href="https://arbor.readthedocs.io/en/latest/install"><b><span class="fa fa-download fa-lg"></span> Install</b></a><a href="https://arbor.readthedocs.io"><b><span class="fa fa-book fa-lg"></span> Documentation</b></a><a href="index.html#get-help"><b><span class="fa fa-question-circle fa-lg"></span> Get Help</b></a></p>
     </header>
     <main>
         <hr>
         <section>
             <header>
-                <h2>Arbor in 1 minute:</h2>
                 <p>
                     Arbor is a library for implementing performance portable network simulations of multi-compartment neuron models.
                     <br>
@@ -51,12 +50,10 @@
             </aside>
             <aside>
                 <h3>Using Arbor</h3>
-                <p>Fits in any workflow</p>
+                <p>Designed for easy workflow integration</p>
                 <p>Written in C++17 and CUDA</p>
-                <p>C++ API for best performance and optimization</p>
-                <p>Python API for easy of use</p>
-                <p>Reporting of memory and energy consumption</p>
-                <p>API for addition of new cell types, e.g. LIF and Poisson spike generators</p>
+                <p>C++ API for high-performance and application integration</p>
+                <p>Python API for ease of use</p>
             </aside>
             <aside>
                 <h3>Development practices</h3>
@@ -64,7 +61,7 @@
                 <p>Open source</p>
                 <p>Unit testing</p>
                 <p>Continuous integration</p>
-                <p>Validation tests against numeric/analytic models and NEURON: <a href="https://nsuite.readthedocs.io/en/latest/" target="_blank">NSuite</a></p>
+                <p>Validation tests against numeric/analytic models and NEURON: <a href="https://nsuite.readthedocs.io/en/latest/">NSuite</a></p>
             </aside>
         </section>
         <hr>


### PR DESCRIPTION
* Change references to "cooperation" to "collaboration".
* A few small text tweaks.
* Use default linking behavior (i.e. don't open links in new tabs).
  - see https://www.w3.org/TR/WCAG20-TECHS/G200.html
